### PR TITLE
Make it possible to configure the hostname for the default server

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ config file.
 - `node['nginx']['group]` - Group for Nginx.
 - `node['nginx']['port']` - Port for nginx to listen on.
 - `node['nginx']['binary']` - Path to the Nginx binary.
+- `node['nginx']['default_hostname']` - The `server_name` for the `default` server.
 - `node['nginx']['upstart']['foreground']` - Set this to true if you
   want upstart to run nginx in the foreground, set to false if you
   want upstart to detach and track the process via pid.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,15 +23,16 @@
 # In order to update the version, the checksum attribute must be changed too.
 # This attribute is in the source.rb file, though we recommend overriding
 # attributes by modifying a role, or the node itself.
-default['nginx']['version']      = '1.4.6-2evertrue1.0'
-default['nginx']['port']         = '80'
-default['nginx']['dir']          = '/etc/nginx'
-default['nginx']['script_dir']   = '/usr/sbin'
-default['nginx']['log_dir']      = '/var/log/nginx'
-default['nginx']['log_dir_perm'] = '0750'
-default['nginx']['binary']       = '/usr/sbin/nginx'
-default['nginx']['default_root'] = '/var/www/nginx-default'
-default['nginx']['ulimit']       = '1024'
+default['nginx']['version']             = '1.4.6-2evertrue1.0'
+default['nginx']['port']                = '80'
+default['nginx']['dir']                 = '/etc/nginx'
+default['nginx']['script_dir']          = '/usr/sbin'
+default['nginx']['log_dir']             = '/var/log/nginx'
+default['nginx']['log_dir_perm']        = '0750'
+default['nginx']['binary']              = '/usr/sbin/nginx'
+default['nginx']['default_hostname']    = node['hostname']
+default['nginx']['default_root']        = '/var/www/nginx-default'
+default['nginx']['ulimit']              = '1024'
 
 default['nginx']['pid'] = '/var/run/nginx.pid'
 

--- a/templates/default/default-site.erb
+++ b/templates/default/default-site.erb
@@ -1,6 +1,6 @@
 server {
   listen   <%= node['nginx']['port'] -%>;
-  server_name  <%= node['hostname'] %>;
+  server_name  <%= node['nginx']['default_hostname'] %>;
 
   access_log  <%= node['nginx']['log_dir'] %>/localhost.access.log;
 


### PR DESCRIPTION
This is needed to fix [our response code regression problem](https://trello.com/c/WnmBPkrq/1107-regression-fix-apis-no-longer-return-403-when-accessed-by-http-instead-of-https)
