### PR TITLE
Make it possible for the default server to return a response code instead of a page

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ config file.
 - `node['nginx']['port']` - Port for nginx to listen on.
 - `node['nginx']['binary']` - Path to the Nginx binary.
 - `node['nginx']['default_hostname']` - The `server_name` for the `default` server.
+- `node['nginx']['default_return_code']` - If set, requests to `default_hostname` will return this instead of trying to load something. Example values are `404` or `301 https://$server_name$request_uri`.
 - `node['nginx']['upstart']['foreground']` - Set this to true if you
   want upstart to run nginx in the foreground, set to false if you
   want upstart to detach and track the process via pid.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,6 +31,7 @@ default['nginx']['log_dir']             = '/var/log/nginx'
 default['nginx']['log_dir_perm']        = '0750'
 default['nginx']['binary']              = '/usr/sbin/nginx'
 default['nginx']['default_hostname']    = node['hostname']
+default['nginx']['default_return_code'] = nil
 default['nginx']['default_root']        = '/var/www/nginx-default'
 default['nginx']['ulimit']              = '1024'
 

--- a/templates/default/default-site.erb
+++ b/templates/default/default-site.erb
@@ -4,8 +4,12 @@ server {
 
   access_log  <%= node['nginx']['log_dir'] %>/localhost.access.log;
 
+  <% if node['nginx']['default_return_code'] -%>
+  return <%= node['nginx']['default_return_code'] %>;
+  <% else -%>
   location / {
     root   <%= node['nginx']['default_root'] %>;
     index  index.html index.htm;
   }
+  <% end -%>
 }


### PR DESCRIPTION
Also needed to fix our [regression](https://trello.com/c/WnmBPkrq/1107-regression-fix-apis-no-longer-return-403-when-accessed-by-http-instead-of-https)
